### PR TITLE
make sure we use Thor style source_root for migration generator

### DIFF
--- a/generators/reportable_migration/reportable_migration_generator.rb
+++ b/generators/reportable_migration/reportable_migration_generator.rb
@@ -2,11 +2,10 @@ class ReportableMigrationGenerator < Rails::Generators::Base
 
   include Rails::Generators::Migration
 
+  source_root File.expand_path('../templates/', __FILE__)
+
   def create_migration
-    migration_template(
-      File.join(File.dirname(__FILE__), 'templates', 'migration.rb'),
-      'db/migrate/create_reportable_cache.rb'
-    )
+    migration_template('migration.rb', 'db/migrate/create_reportable_cache.rb')
   end
 
   def self.next_migration_number(dirname)


### PR DESCRIPTION
This pull request should fix #12 in the migration generator by using Thor's `source_root` method to specify the `templates` folder, instead of absolute paths. I just replicated this from [here](https://github.com/spraints/friendly_id/commit/a84a9bcb67f5a47ee9dcc19720e3267cfe7ccab5)
