### PR TITLE
Make ResultSet Enumerable

### DIFF
--- a/lib/saulabs/reportable/result_set.rb
+++ b/lib/saulabs/reportable/result_set.rb
@@ -9,6 +9,7 @@ module Saulabs
     # was generated from.
     #
     class ResultSet
+      include Enumerable
 
       # the name of the model the result set is based on
       #
@@ -37,6 +38,12 @@ module Saulabs
         @results = array
         @model_name  = model_name
         @report_name = report_name.to_s
+      end
+
+      # quack like an Enumerable
+      #
+      def each(&block)
+        @results.each(&block)
       end
 
     end


### PR DESCRIPTION
Thus you can operate directly on ResultSet objects instead of needing to call `to_a` on them first all the time:

``` ruby
class User < ActiveRecord::Base
  reportable :registrations
end

stats = User.registrations_report(grouping: :weekly, limit: 12)
stats.last  # => [Mon, 22 Oct 2012, 12.0]

# No partial humans :-)
stats.map { |date, value| [date, value.to_i] }

# With no block, get an Enumerator
stats.each  # => #<Enumerator: ...>
```
