### PR TITLE
Make ReportCache.serialize_conditions nil safe

### DIFF
--- a/lib/saulabs/reportable/report_cache.rb
+++ b/lib/saulabs/reportable/report_cache.rb
@@ -129,7 +129,7 @@ module Saulabs
           elsif conditions.is_a?(Hash) && conditions.any?
             conditions.map.sort{|x,y|x.to_s<=>y.to_s}.flatten.join
           else
-            conditions.empty? ? '' : conditions.to_s
+            conditions.blank? ? '' : conditions.to_s
           end
         end
 


### PR DESCRIPTION
# empty? is not nil safe. Use blank instead.
