### PR TITLE
Rename model name

### DIFF
--- a/lib/generators/reportable_migration/templates/migration.rb
+++ b/lib/generators/reportable_migration/templates/migration.rb
@@ -2,7 +2,7 @@ class CreateReportableCache < ActiveRecord::Migration
 
   def self.up
     create_table :reportable_cache, :force => true do |t|
-      t.string   :model_name,       :null => false, :limit => 100
+      t.string   :model_class_name,       :null => false, :limit => 100
       t.string   :report_name,      :null => false, :limit => 100
       t.string   :grouping,         :null => false, :limit => 10
       t.string   :aggregation,      :null => false, :limit => 10
@@ -14,14 +14,14 @@ class CreateReportableCache < ActiveRecord::Migration
     end
 
     add_index :reportable_cache, [
-      :model_name,
+      :model_class_name,
       :report_name,
       :grouping,
       :aggregation,
       :conditions
     ], :name => :name_model_grouping_agregation
     add_index :reportable_cache, [
-      :model_name,
+      :model_class_name,
       :report_name,
       :grouping,
       :aggregation,

--- a/lib/generators/reportable_model_name_migration/USAGE
+++ b/lib/generators/reportable_model_name_migration/USAGE
@@ -1,0 +1,6 @@
+Description:
+    Rename model_name column to model_class_name to be compatible with rails 4.2
+
+Example:
+    rails generate reportable_model_name_migration
+

--- a/lib/generators/reportable_model_name_migration/reportable_model_name_migration_generator.rb
+++ b/lib/generators/reportable_model_name_migration/reportable_model_name_migration_generator.rb
@@ -1,11 +1,10 @@
-class ReportableMigrationGenerator < Rails::Generators::Base
+class ReportableModelNameMigrationGenerator < Rails::Generators::Base
+  source_root File.expand_path('../templates', __FILE__)
 
   include Rails::Generators::Migration
 
-  source_root File.expand_path('../templates/', __FILE__)
-
-  def create_reportable_migration
-    migration_template('migration.rb', 'db/migrate/create_reportable_cache.rb')
+  def create_reportable_model_name_migration
+    migration_template('migration.rb', 'db/migrate/reportable_rename_model_name.rb')
   end
 
   def self.next_migration_number(dirname)
@@ -15,5 +14,6 @@ class ReportableMigrationGenerator < Rails::Generators::Base
       "%.3d" % (current_migration_number(dirname) + 1)
     end
   end
+
 
 end

--- a/lib/generators/reportable_model_name_migration/templates/migration.rb
+++ b/lib/generators/reportable_model_name_migration/templates/migration.rb
@@ -1,0 +1,11 @@
+class RenameReportableCacheModelName < ActiveRecord::Migration
+
+  def self.up
+    rename_column :reportable_cache, :model_name, :model_class_name
+  end
+
+  def self.down
+    rename_column :reportable_cache, :model_class_name, :model_class_name
+  end
+
+end

--- a/lib/saulabs/reportable/railtie.rb
+++ b/lib/saulabs/reportable/railtie.rb
@@ -26,6 +26,7 @@ module Saulabs
 
       generators do
         require File.join(GEM_ROOT, 'lib', 'generators', 'reportable_migration', 'reportable_migration_generator')
+        require File.join(GEM_ROOT, 'lib', 'generators', 'reportable_model_name_migration', 'reportable_model_name_migration_generator')
         require File.join(GEM_ROOT, 'lib', 'generators', 'reportable_raphael_assets', 'reportable_raphael_assets_generator')
         require File.join(GEM_ROOT, 'lib', 'generators', 'reportable_jquery_flot_assets', 'reportable_jquery_flot_assets_generator')
       end

--- a/lib/saulabs/reportable/report_cache.rb
+++ b/lib/saulabs/reportable/report_cache.rb
@@ -7,20 +7,20 @@ module Saulabs
   module Reportable
 
     # The +ReportCache+ class is a regular +ActiveRecord+ model and represents cached results for single {Saulabs::Reportable::ReportingPeriod}s.
-    # +ReportCache+ instances are identified by the combination of +model_name+, +report_name+, +grouping+, +aggregation+ and +reporting_period+.
+    # +ReportCache+ instances are identified by the combination of +model_class_name+, +report_name+, +grouping+, +aggregation+ and +reporting_period+.
     #
     class ReportCache < ActiveRecord::Base
 
       self.table_name = :reportable_cache
 
-      validates_presence_of :model_name
+      validates_presence_of :model_class_name
       validates_presence_of :report_name
       validates_presence_of :grouping
       validates_presence_of :aggregation
       validates_presence_of :value
       validates_presence_of :reporting_period
 
-      # attr_accessible :model_name, :report_name, :grouping, :aggregation, :value, :reporting_period, :conditions
+      # attr_accessible :model_class_name, :report_name, :grouping, :aggregation, :value, :reporting_period, :conditions
 
       self.skip_time_zone_conversion_for_attributes = [:reporting_period]
 
@@ -40,7 +40,7 @@ module Saulabs
       #   Saulabs::Reportable::ReportCache.clear_for(User, :registrations)
       #
       def self.clear_for(klass, report)
-        self.where(model_name: klass.name, report_name: report.to_s).delete_all
+        self.where(model_class_name: klass.name, report_name: report.to_s).delete_all
       end
 
       # Processes the report using the respective cache.
@@ -115,7 +115,7 @@ module Saulabs
 
         def self.build_cached_data(report, grouping, conditions, reporting_period, value)
           self.new(
-            :model_name       => report.klass.to_s,
+            :model_class_name       => report.klass.to_s,
             :report_name      => report.name.to_s,
             :grouping         => grouping.identifier.to_s,
             :aggregation      => report.aggregation.to_s,
@@ -144,7 +144,7 @@ module Saulabs
           start_date = get_first_reporting_period(options).date_time
 
           conditions = where('reporting_period >= ?', start_date).where(
-            model_name: report.klass.to_s,
+            model_class_name: report.klass.to_s,
             report_name: report.name.to_s,
             grouping: options[:grouping].identifier.to_s,
             aggregation: report.aggregation.to_s,

--- a/lib/saulabs/reportable/report_tag_helper.rb
+++ b/lib/saulabs/reportable/report_tag_helper.rb
@@ -84,7 +84,7 @@ module Saulabs
       def raphael_report_tag(data, options = {}, raphael_options = {})
         @__raphael_report_tag_count ||= -1
         @__raphael_report_tag_count += 1
-        default_dom_id = "#{data.model_name.downcase}_#{data.report_name}#{@__raphael_report_tag_count > 0 ? @__raphael_report_tag_count : ''}"
+        default_dom_id = "#{data.model_class_name.downcase}_#{data.report_name}#{@__raphael_report_tag_count > 0 ? @__raphael_report_tag_count : ''}"
         options.reverse_merge!(Config.raphael_options.slice(:width, :height, :format))
         options.reverse_merge!(:dom_id => default_dom_id)
         raphael_options.reverse_merge!(Config.raphael_options.except(:width, :height, :format))
@@ -139,7 +139,7 @@ module Saulabs
       def flot_report_tag(data, options = {}, flot_options = {})
         @__flot_report_tag_count ||= -1
         @__flot_report_tag_count += 1
-        default_dom_id = "#{data.model_name.downcase}_#{data.report_name}#{@__flot_report_tag_count > 0 ? @__flot_report_tag_count : ''}"
+        default_dom_id = "#{data.model_class_name.downcase}_#{data.report_name}#{@__flot_report_tag_count > 0 ? @__flot_report_tag_count : ''}"
         options.reverse_merge!(Config.flot_options.slice(:width, :height, :format))
         options.reverse_merge!(:dom_id => default_dom_id)
         flot_options.reverse_merge!(Config.flot_options.except(:width, :height, :format))

--- a/lib/saulabs/reportable/result_set.rb
+++ b/lib/saulabs/reportable/result_set.rb
@@ -4,7 +4,7 @@ module Saulabs
 
     # A result set as it is returned by the report methods.
     # This is basically a subclass of +Array+ that adds two
-    # attributes, +model_name+ and +report_name+ that store
+    # attributes, +model_class_name+ and +report_name+ that store
     # the name of the model and the report the result set
     # was generated from.
     #
@@ -13,7 +13,7 @@ module Saulabs
 
       # the name of the model the result set is based on
       #
-      attr_reader :model_name
+      attr_reader :model_class_name
 
       # the name of the report the result is based on
       #
@@ -29,14 +29,14 @@ module Saulabs
       #
       # @param [Array] array
       #   the array that is the actual result
-      # @param [String] model_name
+      # @param [String] model_class_name
       #   the name of the model the result set is based on
       # @param [String] report_name
       #   the name of the report the result is based on
       #
-      def initialize(array, model_name, report_name)
+      def initialize(array, model_class_name, report_name)
         @results = array
-        @model_name  = model_name
+        @model_class_name  = model_class_name
         @report_name = report_name.to_s
       end
 

--- a/spec/classes/report_cache_spec.rb
+++ b/spec/classes/report_cache_spec.rb
@@ -10,7 +10,7 @@ describe Saulabs::Reportable::ReportCache do
 
     before do
       @report_cache = Saulabs::Reportable::ReportCache.new(
-        :model_name       => User.name,
+        :model_class_name       => User.name,
         :report_name      => 'registrations',
         :grouping         => 'date',
         :aggregation      => 'count',
@@ -23,14 +23,14 @@ describe Saulabs::Reportable::ReportCache do
       @report_cache.should be_valid
     end
 
-    it 'should not succeed when no model_name is set' do
-      @report_cache.model_name = nil
+    it 'should not succeed when no model_class_name is set' do
+      @report_cache.model_class_name = nil
 
       @report_cache.should_not be_valid
     end
 
-    it 'should not succeed when a blank model_name is set' do
-      @report_cache.model_name = ''
+    it 'should not succeed when a blank model_class_name is set' do
+      @report_cache.model_class_name = ''
 
       @report_cache.should_not be_valid
     end
@@ -190,7 +190,7 @@ describe Saulabs::Reportable::ReportCache do
     xit 'should read existing data from the cache' do
       Saulabs::Reportable::ReportCache.should_receive(:all).once.with(
         :conditions => [
-          %w(model_name report_name grouping aggregation conditions).map do |column_name|
+          %w(model_class_name report_name grouping aggregation conditions).map do |column_name|
             "#{Saulabs::Reportable::ReportCache.connection.quote_column_name(column_name)} = ?"
           end.join(' AND ') + ' AND reporting_period >= ?',
           @report.klass.to_s,
@@ -211,7 +211,7 @@ describe Saulabs::Reportable::ReportCache do
       end_date = Time.now - 1.send(@report.options[:grouping].identifier)
       Saulabs::Reportable::ReportCache.should_receive(:all).once.with(
         :conditions => [
-          %w(model_name report_name grouping aggregation conditions).map do |column_name|
+          %w(model_class_name report_name grouping aggregation conditions).map do |column_name|
             "#{Saulabs::Reportable::ReportCache.connection.quote_column_name(column_name)} = ?"
           end.join(' AND ') + ' AND reporting_period BETWEEN ? AND ?',
           @report.klass.to_s,
@@ -233,7 +233,7 @@ describe Saulabs::Reportable::ReportCache do
       grouping = Saulabs::Reportable::Grouping.new(:month)
       Saulabs::Reportable::ReportCache.should_receive(:all).once.with(
         :conditions => [
-          %w(model_name report_name grouping aggregation conditions).map do |column_name|
+          %w(model_class_name report_name grouping aggregation conditions).map do |column_name|
             "#{Saulabs::Reportable::ReportCache.connection.quote_column_name(column_name)} = ?"
           end.join(' AND ') + ' AND reporting_period >= ?',
           @report.klass.to_s,

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -10,7 +10,7 @@ ActiveRecord::Schema.define(:version => 1) do
   end
 
   create_table :reportable_cache, :force => true do |t|
-    t.string   :model_name,       :null => false, :limit => 100
+    t.string   :model_class_name,       :null => false, :limit => 100
     t.string   :report_name,      :null => false, :limit => 100
     t.string   :grouping,         :null => false, :limit => 10
     t.string   :aggregation,      :null => false, :limit => 10
@@ -21,14 +21,14 @@ ActiveRecord::Schema.define(:version => 1) do
     t.timestamps
   end
   add_index :reportable_cache, [
-    :model_name,
+    :model_class_name,
     :report_name,
     :grouping,
     :aggregation,
     :conditions
   ], :name => 'name_model_grouping_agregation'
   add_index :reportable_cache, [
-    :model_name,
+    :model_class_name,
     :report_name,
     :grouping,
     :aggregation,

--- a/spec/other/report_method_spec.rb
+++ b/spec/other/report_method_spec.rb
@@ -22,7 +22,7 @@ describe Saulabs::Reportable do
   end
 
   it 'should return a result set that stores the name of the model the report was invoked on' do
-    User.registrations_report.model_name.should == User.name
+    User.registrations_report.model_class_name.should == User.name
   end
 
   it 'should return a result set that stores the name of the report that was invoked' do
@@ -36,7 +36,7 @@ describe Saulabs::Reportable do
     end
 
     it 'should return a result set that stores the model the report was invoked on' do
-      SpecialUser.registrations_report.model_name.should == SpecialUser.name
+      SpecialUser.registrations_report.model_class_name.should == SpecialUser.name
     end
 
     it 'should include all data when invoked on the base model class' do

--- a/spec/other/report_tag_helper_spec.rb
+++ b/spec/other/report_tag_helper_spec.rb
@@ -25,12 +25,12 @@ describe Saulabs::Reportable::ReportTagHelper do
     end
 
     it 'should assign a default dom id to the the div tag if none is specified' do
-      @helper.raphael_report_tag(data_set).should =~ /^<div id="#{data_set.model_name.downcase}_#{data_set.report_name}".*<\/div>/
+      @helper.raphael_report_tag(data_set).should =~ /^<div id="#{data_set.model_class_name.downcase}_#{data_set.report_name}".*<\/div>/
     end
 
     it 'should assign correct default dom ids to the the div tag if none is specified and there are more than one report tags on the page' do
-      @helper.raphael_report_tag(data_set).should =~ /^<div id="#{data_set.model_name.downcase}_#{data_set.report_name}".*<\/div>/
-      @helper.raphael_report_tag(data_set).should =~ /^<div id="#{data_set.model_name.downcase}_#{data_set.report_name}1".*<\/div>/
+      @helper.raphael_report_tag(data_set).should =~ /^<div id="#{data_set.model_class_name.downcase}_#{data_set.report_name}".*<\/div>/
+      @helper.raphael_report_tag(data_set).should =~ /^<div id="#{data_set.model_class_name.downcase}_#{data_set.report_name}1".*<\/div>/
     end
     
     it 'should include the data [1,3]' do
@@ -56,12 +56,12 @@ describe Saulabs::Reportable::ReportTagHelper do
     end
 
     it 'should assign a default dom id to the the div tag if none is specified' do
-      @helper.flot_report_tag(data_set).should =~ /^<div id="#{data_set.model_name.downcase}_#{data_set.report_name}".*<\/div>/
+      @helper.flot_report_tag(data_set).should =~ /^<div id="#{data_set.model_class_name.downcase}_#{data_set.report_name}".*<\/div>/
     end
 
     it 'should assign correct default dom ids to the the div tag if none is specified and there are more than one report tags on the page' do
-      @helper.flot_report_tag(data_set).should =~ /^<div id="#{data_set.model_name.downcase}_#{data_set.report_name}".*<\/div>/
-      @helper.flot_report_tag(data_set).should =~ /^<div id="#{data_set.model_name.downcase}_#{data_set.report_name}1".*<\/div>/
+      @helper.flot_report_tag(data_set).should =~ /^<div id="#{data_set.model_class_name.downcase}_#{data_set.report_name}".*<\/div>/
+      @helper.flot_report_tag(data_set).should =~ /^<div id="#{data_set.model_class_name.downcase}_#{data_set.report_name}1".*<\/div>/
     end
 
   end


### PR DESCRIPTION
Rename model_name to model_class_name for rails 4.2 compatibility. 
To update, you must generate and run the migration:

    bundle exec rails generate reportable_model_name_migration
    bundle exec rake db:migrate

Fixes #36.