### PR TITLE
Fix Arel sql warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem 'rails', '~> 4.1.0'
+gem 'rails', '~> 5.0.1'
 gem 'protected_attributes'
 
 gem 'sqlite3'

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+v1.5.0
+------
+* Upgrade to ruby 2.3.1
+
 v1.4.2
 ------
 * Revert "Make ResultSet enumerable"
@@ -6,7 +10,7 @@ v1.4.0
 ------
 
 * rename model_name to model_class_name for rails 4.2 compatibility
-    
+
     to update, you must generate and run the migration
 
     	bundle exec rails generate reportable_model_name_migration

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Reportable
 
 Reportable allows for the easy creation of reports based on `ActiveRecord` models.
 
+octanner fork to support ruby 2.3.1
 
 Usage
 -----

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Reportable
 
 Reportable allows for the easy creation of reports based on `ActiveRecord` models.
 
-octanner fork to support ruby 2.3.1
+**O.C.Tanner fork to support ruby 2.3.1**
 
 Usage
 -----

--- a/lib/saulabs/reportable/report.rb
+++ b/lib/saulabs/reportable/report.rb
@@ -122,7 +122,7 @@ module Saulabs
           table_name = ActiveRecord::Base.connection.quote_table_name(@klass.table_name)
           date_column = ActiveRecord::Base.connection.quote_column_name(@date_column.to_s)
           grouping = options[:grouping].to_sql("#{table_name}.#{date_column}")
-          order    = "#{grouping} ASC"
+          order    = Arel.sql("#{grouping} ASC")
 
           @klass.where(conditions).includes(options[:include]).distinct(options[:distinct]).
             group(grouping).order(order).limit(options[:limit]).

--- a/lib/saulabs/reportable/report_cache.rb
+++ b/lib/saulabs/reportable/report_cache.rb
@@ -86,7 +86,7 @@ module Saulabs
 
         def self.prepare_result(new_data, cached_data, report, options)
           new_data = new_data.to_a.map { |data| [ReportingPeriod.from_db_string(options[:grouping], data[0]), data[1]] }
-          cached_data.to_a.map! { |cached| [ReportingPeriod.new(options[:grouping], cached.reporting_period), cached.value] }
+          cached_data = cached_data.to_a.map { |cached| [ReportingPeriod.new(options[:grouping], cached.reporting_period), cached.value] }
           current_reporting_period = ReportingPeriod.new(options[:grouping])
           reporting_period = get_first_reporting_period(options)
           result = []

--- a/reportable.gemspec
+++ b/reportable.gemspec
@@ -14,7 +14,7 @@ pkg_files += Dir['spec/**/*.{rb,yml,opts}']
 Gem::Specification.new do |s|
 
   s.name    = %q{reportable}
-  s.version = '1.4.2'
+  s.version = '1.5.0'
 
   s.required_rubygems_version = Gem::Requirement.new('>= 0') if s.respond_to?(:required_rubygems_version=)
   s.authors                   = ['Marco Otte-Witte', 'Martin Kavalar']


### PR DESCRIPTION


`DEPRECATION WARNING: Dangerous query method (method whose arguments are used as raw SQL) called with non-attribute argument(s): "date_trunc('month', \"print_audits\".\"created_at\") ASC". Non-attribute arguments will be disallowed in Rails 6.0. This method should not be called with user-provided values, such as request parameters or model attributes. Known-safe values can be passed by wrapping them in Arel.sql(). (called from read_data at ...vendor/bundle/ruby/2.5.0/bundler/gems/reportable-44ebda7bd3a6/lib/saulabs/reportable/report.rb:128)`

